### PR TITLE
Add results header to questionnaire

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,58 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Cuestionario de Ansiedad</title>
-    <link rel="stylesheet" href="../CSS/style.css">
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <h1>Cuestionario de Ansiedad</h1>
+    <section id="datos-personales">
+        <h2>RESULTADOS AUTOEVALUACION EAA ZUNG</h2>
+        <table>
+            <tbody>
+                <tr>
+                    <td>Nombre</td>
+                    <td><input type="text" id="nombre"></td>
+                </tr>
+                <tr>
+                    <td>Edad</td>
+                    <td><input type="number" id="edad"></td>
+                </tr>
+                <tr>
+                    <td>Fecha de Ev.</td>
+                    <td><input type="date" id="fechaEv"></td>
+                </tr>
+                <tr>
+                    <td>Derivado por</td>
+                    <td><input type="text" id="derivadoPor"></td>
+                </tr>
+                <tr>
+                    <td>Evaluado por</td>
+                    <td><input type="text" id="evaluadoPor"></td>
+                </tr>
+                <tr>
+                    <td>Derivado a</td>
+                    <td><input type="text" id="derivadoA"></td>
+                </tr>
+            </tbody>
+        </table>
+        <table>
+            <thead>
+                <tr>
+                    <th>PUNTAJE</th>
+                    <th>INDICE</th>
+                    <th>DIAGNOSTICO EAA</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td id="puntaje"></td>
+                    <td id="indice"></td>
+                    <td id="diagnostico"></td>
+                </tr>
+            </tbody>
+        </table>
+        <p>TOTAL EAA: <span id="totalEaa"></span></p>
+    </section>
     <form id="anxietyForm">
         <table>
             <thead>
@@ -168,6 +216,6 @@
     <button type="submit">Calcular</button>
     <p id="resultado"></p>
     </form>
-    <script src="../JS/main.js"></script>
+    <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,5 +1,9 @@
 const form = document.getElementById('anxietyForm');
 const resultParagraph = document.getElementById('resultado');
+const puntajeCell = document.getElementById('puntaje');
+const indiceCell = document.getElementById('indice');
+const diagnosticoCell = document.getElementById('diagnostico');
+const totalEaaSpan = document.getElementById('totalEaa');
 
 form.addEventListener('submit', function (e) {
     e.preventDefault();
@@ -8,5 +12,20 @@ form.addEventListener('submit', function (e) {
     inputs.forEach(input => {
         total += parseInt(input.value, 10);
     });
+    const indice = total * 1.25;
+    let diagnostico = '';
+    if (total <= 44) {
+        diagnostico = 'Normal';
+    } else if (total <= 59) {
+        diagnostico = 'Ansiedad Leve';
+    } else if (total <= 74) {
+        diagnostico = 'Ansiedad Moderada';
+    } else {
+        diagnostico = 'Ansiedad Severa';
+    }
+    puntajeCell.textContent = total;
+    indiceCell.textContent = indice.toFixed(2);
+    diagnosticoCell.textContent = diagnostico;
+    totalEaaSpan.textContent = total;
     resultParagraph.textContent = `Puntaje total: ${total}`;
 });


### PR DESCRIPTION
## Summary
- add Zung self-assessment results section before questionnaire
- compute index and diagnosis in JavaScript
- fix asset paths

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684365ee902c8328b904299b5a6c06c2